### PR TITLE
some small fixes in program.cs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -62,14 +62,15 @@ async Task db_reset_to_default(Config config)
   CREATE TABLE countries
   (
   id INT PRIMARY KEY AUTO_INCREMENT,
-  name VARCHAR(100)
+  name VARCHAR(100) NOT NULL
   );
 
   CREATE TABLE locations
   (
   id INT PRIMARY KEY AUTO_INCREMENT,
-  contryId INT REFERENCES contries(id),
-  city VARCHAR (100)
+  countries_id INT NOT NULL,
+  city VARCHAR (100) NOT NULL,
+  FOREIGN KEY (countries_id) REFERENCES countries(id)
   );
 
   
@@ -81,16 +82,16 @@ async Task db_reset_to_default(Config config)
   address VARCHAR(255) NOT NULL,
   price_class INT NOT NULL, 
   has_breakfast BOOL NOT NULL DEFAULT FALSE,
-  FOREIGN KEY (location_id) REFERENCES location(id)
+  FOREIGN KEY (location_id) REFERENCES locations(id)
   );
 
   CREATE TABLE rooms
   (
   id INT PRIMARY KEY AUTO_INCREMENT,
   hotel_id INT NOT NULL,
-  name ENUM ('Single', 'Double', 'Suit'),
-  capacity INT,
-  price_per_night DECIMAL,
+  name ENUM ('Single', 'Double', 'Suite'),
+  capacity INT NOT NULL,
+  price_per_night DECIMAL(10,2) NOT NULL,
   FOREIGN KEY (hotel_id) REFERENCES hotels(id)
   );   
 
@@ -108,16 +109,16 @@ async Task db_reset_to_default(Config config)
 
   """;
 
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS users");
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS password_request");
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS hotels");
   await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS rooms");
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS countries");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS hotels");
   await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS locations");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS countries");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS password_request");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "DROP TABLE IF EXISTS users");
   await MySqlHelper.ExecuteNonQueryAsync(config.db, users_create);
   await MySqlHelper.ExecuteNonQueryAsync(config.db, "INSERT INTO users(email, first_name, last_name, date_of_birth, password) VALUES ('edvin@example.com', 'Edvin', 'Linconfig.dborg', '1997-08-20', 'travelagency')");
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "INSERT INTO `countries` (id, name) VALUES (1,'Sweden'),(2,'Norway'),(3,'Denmark')");
-  await MySqlHelper.ExecuteNonQueryAsync(config.db, "INSERT INTO `locations` VALUES(1, 1, 'Stockholm'),(2, 1, 'Malmoe'),(3, 1, 'Gothenburg'),(4, 2, 'Copenhagen'),(5, 2, 'Aarhus'),(6, 2, 'Rodby'),(7, 3, 'Oslo'),(8, 3, 'Stavanger'),(9, 3, 'Bergen')");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "INSERT INTO countries (id, name) VALUES (1,'Sweden'),(2,'Norway'),(3,'Denmark')");
+  await MySqlHelper.ExecuteNonQueryAsync(config.db, "INSERT INTO locations VALUES(1, 1, 'Stockholm'),(2, 1, 'Malmoe'),(3, 1, 'Gothenburg'),(4, 2, 'Copenhagen'),(5, 2, 'Aarhus'),(6, 2, 'Rodby'),(7, 3, 'Oslo'),(8, 3, 'Stavanger'),(9, 3, 'Bergen')");
 
   // await MySqlHelper.ExecuteNonQueryAsync(config.db, "CALL create_password_request('edvin@example.com')");
   //, NOW() + INTERVAL 1 DAY


### PR DESCRIPTION
Fixed some minor spelling errors, added reference to foreign key syntax, corrected the syntax and corrected the way the way tables drop in the correct order. Starting with the child reference, so that we don't get any problem with FK or rows left after dropping the db.